### PR TITLE
overspecify experiment

### DIFF
--- a/color.css
+++ b/color.css
@@ -8,11 +8,11 @@
   background: #111;
 }
 
-:link {
+[href]:link {
   color: hotpink;
 }
 
-:visited {
+[href]:visited {
   color: violet;
 }
 


### PR DESCRIPTION
these `:link` and `:visited` work in FF but in mobile safari they appear default link blue 

this change ups their specificity to test difference